### PR TITLE
[INFRA-3066] Try using a `Bearer` token rather than `Basic` auth

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -3,8 +3,14 @@
     <servers>
         <server>
             <id>maven.jenkins-ci.org</id>
-            <username>${env.MAVEN_USERNAME}</username>
-            <password>${env.MAVEN_TOKEN}</password>
+            <configuration>
+                <httpHeaders>
+                    <property>
+                        <name>Authorization</name>
+                        <value>Bearer ${env.MAVEN_TOKEN}</value>
+                    </property>
+                </httpHeaders>
+            </configuration>
         </server>
     </servers>
 </settings>


### PR DESCRIPTION
Fixes #8. (or so I hope) https://issues.jenkins.io/browse/INFRA-3066
