### PR TITLE
Fixes #11: Release even without .gitignore

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ then
 fi
 export MAVEN_OPTS=-Djansi.force=true
 mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
-version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
+version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout -Dignore.dirt help:evaluate)
 gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
 release=$(gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .id')
 gh api -X PATCH -F draft=false -F name=$version -F tag_name=$version /repos/$GITHUB_REPOSITORY/releases/$release


### PR DESCRIPTION
No .gitignore or no `/target` in .gitignore results release failure.
Worse, artifacts are uploaded but no release is created in github.

Please have a look on #11 for the detailed situation.
