### PR TITLE
Support clean release version without changelist

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -14,8 +14,14 @@ inputs:
       By default excludes 📦📝👻🚦 under the assumption these do not normally merit a release.
       Ignored when using workflow_dispatch (explicit release); when using the check_run trigger (automatic), the release is skipped unless the draft changelog matches.
     default: '[💥🚨🎉🐛⚠🚀👷]|:(boom|tada|construction_worker):'
+  NO_CHANGELIST:
+    required: true
+    description: |
+      If specified, the release won't have an incremental suffix. Instead it will just be "project.revision" from pom.xml.
+      By default uses such incremental suffix. Set to a truthy value (e.g. '1') to prevent an incremental suffix.
+    default: ''
 runs:
   using: composite
   steps: 
-    - run: GITHUB_TOKEN=${{ inputs.GITHUB_TOKEN }} MAVEN_USERNAME=${{ inputs.MAVEN_USERNAME }} MAVEN_TOKEN=${{ inputs.MAVEN_TOKEN }} INTERESTING_CATEGORIES='${{ inputs.INTERESTING_CATEGORIES }}' $GITHUB_ACTION_PATH/run.sh
+    - run: GITHUB_TOKEN=${{ inputs.GITHUB_TOKEN }} MAVEN_USERNAME=${{ inputs.MAVEN_USERNAME }} MAVEN_TOKEN=${{ inputs.MAVEN_TOKEN }} INTERESTING_CATEGORIES='${{ inputs.INTERESTING_CATEGORIES }}' NO_CHANGELIST='${{ inputs.NO_CHANGELIST }}' $GITHUB_ACTION_PATH/run.sh
       shell: bash

--- a/run.sh
+++ b/run.sh
@@ -4,9 +4,16 @@ if [ $GITHUB_EVENT_NAME = check_run ]
 then
     gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .body' | egrep "$INTERESTING_CATEGORIES"
 fi
+
+MVN_CHANGELIST_OPTION=-Dset.changelist
+if [ -n "${NO_CHANGELIST}" ]
+then
+    MVN_CHANGELIST_OPTION=-Dchangelist=
+fi
+
 export MAVEN_OPTS=-Djansi.force=true
-mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
-version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
+mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always $MVN_CHANGELIST_OPTION -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
+version=$(mvn -B -ntp $MVN_CHANGELIST_OPTION -Dexpression=project.version -q -DforceStdout help:evaluate)
 gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
 release=$(gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .id')
 gh api -X PATCH -F draft=false -F name=$version -F tag_name=$version /repos/$GITHUB_REPOSITORY/releases/$release


### PR DESCRIPTION
Many plugins have a clean version for a stable release, such as [Blue Ocean](https://github.com/jenkinsci/blueocean-plugin/releases) or similar. It seems that they don't use this workflow action as it currently creates releases such as for the [Gitea plugin](https://github.com/jenkinsci/gitea-plugin/releases/tag/1.4.0--rc182.9eb947470fcf).

This PR adds the possibility to opt-out incremental/snapshot/rc suffixes during plugin release/deploy and for creating the actual GitHub release from a previously created draft. By default the suffix will be used.

Additionally resolves: #6 