### PR TITLE
Support `maven-release-plugin`

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,8 +5,15 @@ then
     gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .body' | egrep "$INTERESTING_CATEGORIES"
 fi
 export MAVEN_OPTS=-Djansi.force=true
-mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
-version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
-gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
+if fgrep -sq changelist.format .mvn/maven.config
+then # JEP-229
+    mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
+    version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
+    gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
+else # MRP
+    mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -P\!consume-incrementals -Darguments=-Pquick-build validate release:prepare release:perform
+    git checkout HEAD^ # tagged version, rather than prepare for next development version
+    version=$(mvn -B -ntp -Dexpression=project.version -q -DforceStdout help:evaluate)
+fi
 release=$(gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .id')
 gh api -X PATCH -F draft=false -F name=$version -F tag_name=$version /repos/$GITHUB_REPOSITORY/releases/$release

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ then # JEP-229
     version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
     gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
     name=next
+    tag=$version
 else # MRP
     git config --global user.email cd@jenkins.io
     git config --global user.name jenkins-maven-cd-action
@@ -19,6 +20,7 @@ else # MRP
     git checkout HEAD^ # tagged version, rather than prepare for next development version
     version=$(mvn -B -ntp -Dexpression=project.version -q -DforceStdout help:evaluate)
     name=$version # TODO why does this work differently than in JEP-229?
+    tag=$(git describe HEAD) # typically ${project.artifactId}-${version}
 fi
 release=$(gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r --arg name $name '.[] | select(.draft == true and .name == $name) | .id')
-gh api -X PATCH -F draft=false -F name=$version -F tag_name=$version /repos/$GITHUB_REPOSITORY/releases/$release
+gh api -X PATCH -F draft=false -F name=$version -F tag_name=$tag /repos/$GITHUB_REPOSITORY/releases/$release

--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,7 @@ else # MRP
     insteadOf = git@github.com:
 EOF
     echo https://git:$GITHUB_TOKEN@github.com >> ~/.git-credentials
+    git config -l # TODO debugging
     mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -P\!consume-incrementals -Darguments='-Pquick-build -ntp' validate release:prepare release:perform
     git checkout HEAD^ # tagged version, rather than prepare for next development version
     version=$(mvn -B -ntp -Dexpression=project.version -q -DforceStdout help:evaluate)

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,6 @@ else # MRP
     git config --global user.email cd@jenkins.io
     git config --global user.name jenkins-maven-cd-action
     git config --global url.https://github.com/.insteadOf git@github.com:
-    git config -l # TODO debugging
     mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -P\!consume-incrementals -Darguments='-Pquick-build -ntp' validate release:prepare release:perform
     git checkout HEAD^ # tagged version, rather than prepare for next development version
     version=$(mvn -B -ntp -Dexpression=project.version -q -DforceStdout help:evaluate)

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ then # JEP-229
     version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
     gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
 else # MRP
-    mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -P\!consume-incrementals -Darguments=-Pquick-build validate release:prepare release:perform
+    mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -P\!consume-incrementals -Darguments='-Pquick-build -ntp' validate release:prepare release:perform
     git checkout HEAD^ # tagged version, rather than prepare for next development version
     version=$(mvn -B -ntp -Dexpression=project.version -q -DforceStdout help:evaluate)
 fi

--- a/run.sh
+++ b/run.sh
@@ -11,14 +11,9 @@ then # JEP-229
     version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
     gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
 else # MRP
-    echo >> ~/.gitconfig <<EOF
-[user]
-    name = jenkins-maven-cd-action
-    email = noreply@jenkins.io
-[url "https://github.com/"]
-    insteadOf = git@github.com:
-EOF
-    echo https://git:$GITHUB_TOKEN@github.com >> ~/.git-credentials
+    git config --global user.email cd@jenkins.io
+    git config --global user.name jenkins-maven-cd-action
+    git config --global url.https://github.com/.insteadOf git@github.com:
     git config -l # TODO debugging
     mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -P\!consume-incrementals -Darguments='-Pquick-build -ntp' validate release:prepare release:perform
     git checkout HEAD^ # tagged version, rather than prepare for next development version

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,8 @@ then # JEP-229
     version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
     gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
 else # MRP
+    git config user.email cd@jenkins.io
+    git config user.name "jenkins-maven-cd-action in $GITHUB_REPOSITORY"
     mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -P\!consume-incrementals -Darguments='-Pquick-build -ntp' validate release:prepare release:perform
     git checkout HEAD^ # tagged version, rather than prepare for next development version
     version=$(mvn -B -ntp -Dexpression=project.version -q -DforceStdout help:evaluate)

--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,7 @@ then # JEP-229
     mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
     version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
     gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
+    name=next
 else # MRP
     git config --global user.email cd@jenkins.io
     git config --global user.name jenkins-maven-cd-action
@@ -17,6 +18,7 @@ else # MRP
     mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -P\!consume-incrementals -Darguments='-Pquick-build -ntp' validate release:prepare release:perform
     git checkout HEAD^ # tagged version, rather than prepare for next development version
     version=$(mvn -B -ntp -Dexpression=project.version -q -DforceStdout help:evaluate)
+    name=$version # TODO why does this work differently than in JEP-229?
 fi
-release=$(gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .id')
+release=$(gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r --arg name $name '.[] | select(.draft == true and .name == $name) | .id')
 gh api -X PATCH -F draft=false -F name=$version -F tag_name=$version /repos/$GITHUB_REPOSITORY/releases/$release

--- a/run.sh
+++ b/run.sh
@@ -11,8 +11,14 @@ then # JEP-229
     version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
     gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
 else # MRP
-    git config user.email cd@jenkins.io
-    git config user.name "jenkins-maven-cd-action in $GITHUB_REPOSITORY"
+    echo >> ~/.gitconfig <<EOF
+[user]
+    name = jenkins-maven-cd-action
+    email = noreply@jenkins.io
+[url "https://github.com/"]
+    insteadOf = git@github.com:
+EOF
+    echo https://git:$GITHUB_TOKEN@github.com >> ~/.git-credentials
     mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -P\!consume-incrementals -Darguments='-Pquick-build -ntp' validate release:prepare release:perform
     git checkout HEAD^ # tagged version, rather than prepare for next development version
     version=$(mvn -B -ntp -Dexpression=project.version -q -DforceStdout help:evaluate)


### PR DESCRIPTION
https://groups.google.com/g/jenkinsci-dev/c/i348jNcX7pY/m/Rrn453pWAAAJ

Working in `build-token-root`. If merged, will need to update https://www.jenkins.io/doc/developer/publishing/releasing-cd/ accordingly.