### PR TITLE
fix: retrieve only last `next` release draft

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,5 +8,5 @@ export MAVEN_OPTS=-Djansi.force=true
 mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
 version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
 gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
-release=$(gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .id')
+release=$(gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '[ .[] | select(.draft == true and .name == "next").id] | max')
 gh api -X PATCH -F draft=false -F name=$version -F tag_name=$version /repos/$GITHUB_REPOSITORY/releases/$release

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 if [ $GITHUB_EVENT_NAME = check_run ]
 then
-    gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .body' | egrep "$INTERESTING_CATEGORIES"
+    gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '[ .[] | select(.draft == true and .name == "next")] | max_by(.id).body' | egrep "$INTERESTING_CATEGORIES"
 fi
 export MAVEN_OPTS=-Djansi.force=true
 mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy


### PR DESCRIPTION
As noted in https://github.com/jenkins-infra/pipeline-library/issues/379 ([which took its inspiration from here](https://github.com/jenkins-infra/pipeline-library/pull/380#issuecomment-1127855955)), if there are more than one `next` release drafts, this script fails as jq then returns a multiline string.