### PR TITLE
feat: create an annotated tag instead of a ligthweight tag to ensure the correct timestamp

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,10 @@ fi
 export MAVEN_OPTS=-Djansi.force=true
 mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
 version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
+# Create the annotated git tag - https://docs.github.com/en/rest/git/tags#create-a-tag-object
+gh api -F tag=$version -F message=$version -F object=$GITHUB_SHA -F type=commit /repos/$GITHUB_REPOSITORY/git/tag
+# Create the git reference associated to the annotated git tag - https://docs.github.com/en/rest/git/refs#create-a-reference
 gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
+# Publish the GitHub draft release and associate it with the git tag - https://docs.github.com/en/rest/releases/releases#update-a-release
 release=$(gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '[ .[] | select(.draft == true and .name == "next").id] | max')
 gh api -X PATCH -F draft=false -F name=$version -F tag_name=$version /repos/$GITHUB_REPOSITORY/releases/$release

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ export MAVEN_OPTS=-Djansi.force=true
 mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
 version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
 # Create the annotated git tag - https://docs.github.com/en/rest/git/tags#create-a-tag-object
-gh api -F tag=$version -F message=$version -F object=$GITHUB_SHA -F type=commit /repos/$GITHUB_REPOSITORY/tags
+gh api -F tag=$version -F message=$version -F object=$GITHUB_SHA -F type=commit /repos/$GITHUB_REPOSITORY/git/tags
 # Create the git reference associated to the annotated git tag - https://docs.github.com/en/rest/git/refs#create-a-reference
 gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
 # Publish the GitHub draft release and associate it with the git tag - https://docs.github.com/en/rest/releases/releases#update-a-release

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ export MAVEN_OPTS=-Djansi.force=true
 mvn -B -V -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
 version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
 # Create the annotated git tag - https://docs.github.com/en/rest/git/tags#create-a-tag-object
-gh api -F tag=$version -F message=$version -F object=$GITHUB_SHA -F type=commit /repos/$GITHUB_REPOSITORY/git/tag
+gh api -F tag=$version -F message=$version -F object=$GITHUB_SHA -F type=commit /repos/$GITHUB_REPOSITORY/tags
 # Create the git reference associated to the annotated git tag - https://docs.github.com/en/rest/git/refs#create-a-reference
 gh api -F ref=refs/tags/$version -F sha=$GITHUB_SHA /repos/$GITHUB_REPOSITORY/git/refs
 # Publish the GitHub draft release and associate it with the git tag - https://docs.github.com/en/rest/releases/releases#update-a-release


### PR DESCRIPTION
This PR fixes https://github.com/jenkins-infra/jenkins-maven-cd-action/issues/25.

It ensures that an annotated tag is created before publishing the release.

It follows the official Git API documentation about creating tags in https://docs.github.com/en/rest/git/tags#create-a-tag-object:

> Note that creating a tag object does not [create](https://docs.github.com/rest/reference/git#create-a-reference) the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then create the refs/tags/[tag] reference. If you want to [create](https://docs.github.com/rest/reference/git#create-a-reference) a lightweight tag, you only have to create the tag reference - this call would be unnecessary.


Note: I have no idea how to properly test this in "real life" scenario. I tried in https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/45 but it seems that we use 2 levels of actions and there are "local" actions (e.g. restricted to the organization).

I'll try to publish my modified action to gh action and work with it but it's not really easy: any tip is welcome