### PR TITLE
use modern syntax for altDeploymentLocation

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ then
     gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '[ .[] | select(.draft == true and .name == "next")] | max_by(.id).body' | egrep "$INTERESTING_CATEGORIES"
 fi
 export MAVEN_OPTS=-Djansi.force=true
-mvn -B -V -e -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
+mvn -B -V -e -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::https://repo.jenkins-ci.org/releases/ -Pquick-build -P\!consume-incrementals clean deploy
 version=$(mvn -B -ntp -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate)
 # Create the annotated git tag - https://docs.github.com/en/rest/git/tags#create-a-tag-object
 gh api -F tag=$version -F message=$version -F object=$GITHUB_SHA -F type=commit /repos/$GITHUB_REPOSITORY/git/tags


### PR DESCRIPTION
when performing a CD release the build produces warnings about old formats for `altDeploymentLocation`

```
[INFO] --- maven-deploy-plugin:3.1.1:deploy (default-deploy) @ aws-java-sdk-parent ---
[INFO] Using alternate deployment repository maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/
[WARNING] Using legacy syntax for alternative repository. Use "maven.jenkins-ci.org::https://repo.jenkins-ci.org/releases/" instead.
```

This requires maven 3 (as noted by https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html#altDeploymentRepository) - and there should IIUC be no need to support maven 2.

> Note: In version 2.x, the format was id::layout::url where layout could be default (ie. Maven 2) or legacy (ie. Maven 1), but since 3.0.0 the layout part has been removed because Maven 3 only supports Maven 2 repository layout.

Note: this is completely untested but should fix #24 

